### PR TITLE
Fix SIGSEGV if main thread is interrupted by boost

### DIFF
--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -422,6 +422,11 @@ void HomotopyClassPlanner::optimizeAllTEBs(int iter_innerloop, int iter_outerloo
   // optimize TEBs in parallel since they are independend of each other
   if (cfg_->hcp.enable_multithreading)
   {
+    // Must prevent .join_all() from throwing exception if interruption was
+    // requested, as this can lead to multiple threads operating on the same
+    // TEB, which leads to SIGSEGV
+    boost::this_thread::disable_interruption di;
+
     boost::thread_group teb_threads;
     for (TebOptPlannerContainer::iterator it_teb = tebs_.begin(); it_teb != tebs_.end(); ++it_teb)
     {


### PR DESCRIPTION
The problem was that boost::thread_group::join_all() is a boost interruption
point, so will exit early with an exception if someone requests that this
threathread be interrupted. But if that happens, then the thread(s) we were
waiting on continues running. On next planner iteration, we may create a new
thread to operate on the same TEB object, leading to data corruption.

The solution is simple: Disable thread interruption during optimizeAllTEBs().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/teb_local_planner/4)
<!-- Reviewable:end -->
