### PR TITLE
Add inflation_cost_exponent param for nonlinear cost

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -300,9 +300,12 @@ grp_optimization.add("weight_adapt_factor", double_t, 0,
   2, 1, 100) 
 
 grp_optimization.add("obstacle_cost_exponent", double_t, 0,
-	"Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)",
+	"Exponent for nonlinear obstacle cost (cost = min_obstacle_dist * pow([fraction of possible linear_cost], obstacle_cost_exponent)). Set to 1 to disable nonlinear cost (default)",
 	1, 0.01, 100)
 
+grp_optimization.add("inflation_cost_exponent", double_t, 0,
+	"Exponent for nonlinear obstacle inflation cost (cost = inflation_dist * pow([fraction of possible inflation_cost], inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)",
+	1, 0.01, 100)
   
   
 # Homotopy Class Planner

--- a/include/teb_local_planner/g2o_types/edge_obstacle.h
+++ b/include/teb_local_planner/g2o_types/edge_obstacle.h
@@ -242,9 +242,13 @@ public:
       _error[0] = cfg_->obstacles.min_obstacle_dist * std::pow(_error[0] / cfg_->obstacles.min_obstacle_dist, cfg_->optim.obstacle_cost_exponent);
     }
 
-    // Additional linear inflation cost
+    // Additional inflation cost
     _error[1] = penaltyBoundFromBelow(dist, cfg_->obstacles.inflation_dist, 0.0);
-
+    if (cfg_->optim.inflation_cost_exponent != 1.0 && cfg_->obstacles.inflation_dist > 0.0)
+    {
+      // Optional non-linear inflation cost. See comment above about obstacle_cost_exponent.
+      _error[1] = cfg_->obstacles.inflation_dist * std::pow(_error[1] / cfg_->obstacles.inflation_dist, cfg_->optim.inflation_cost_exponent);
+    }
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]) && std::isfinite(_error[1]), "EdgeInflatedObstacle::computeError() _error[0]=%f, _error[1]=%f\n",_error[0], _error[1]);
   }

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -161,7 +161,8 @@ public:
     double weight_prefer_rotdir; //!< Optimization weight for preferring a specific turning direction (-> currently only activated if an oscillation is detected, see 'oscillation_recovery'
 
     double weight_adapt_factor; //!< Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new = weight_old*factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.
-    double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)
+    double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = min_obstacle_dist * pow([fraction of possible linear_cost], obstacle_cost_exponent)). Set to 1 to disable nonlinear cost (default)
+    double inflation_cost_exponent; //!< Exponent for nonlinear obstacle inflation cost (cost = inflation_dist * pow([fraction of possible inflation_cost], inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)
   } optim; //!< Optimization related parameters
 
 
@@ -315,6 +316,7 @@ public:
 
     optim.weight_adapt_factor = 2.0;
     optim.obstacle_cost_exponent = 1.0;
+    optim.inflation_cost_exponent = 1.0;
 
     // Homotopy Class Planner
 

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -127,6 +127,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
   nh.param("obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
+  nh.param("inflation_cost_exponent", optim.inflation_cost_exponent, optim.inflation_cost_exponent);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -246,6 +247,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;
+  optim.inflation_cost_exponent = cfg.inflation_cost_exponent;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;


### PR DESCRIPTION
As with the main obstacle cost (based on min_obstacle_dist), a large
inflation distance leads to instability in path optimization due to the
sum of the straight-line inflation costs of obstacles on opposite sides of the
trajectory being a horizontal line (with zero derivative). Again, the solution is to make this cost function non-linear.

Add new parameter inflation_cost_exponent. When set to any positive
number, this will make the inflation cost nonlinear. The entire cost
curve is lower than the linear cost, so a corresponding increase in
inflation_weight may be needed.

Augments: 70382cb8eb ("Add nonlinear part to obstacle cost to improve
                       narrow gap [behavior]")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/teb_local_planner/6)
<!-- Reviewable:end -->
