### PR TITLE
H signature fixes

### DIFF
--- a/include/teb_local_planner/equivalence_relations.h
+++ b/include/teb_local_planner/equivalence_relations.h
@@ -39,6 +39,7 @@
 #ifndef EQUIVALENCE_RELATIONS_H_
 #define EQUIVALENCE_RELATIONS_H_
 
+#include <complex>
 #include <boost/shared_ptr.hpp>
 
 namespace teb_local_planner
@@ -63,6 +64,7 @@ namespace teb_local_planner
 class EquivalenceClass
 {
 public:
+   typedef std::complex<long double> cplx;
 
    /**
     * @brief Default constructor

--- a/include/teb_local_planner/graph_search.h
+++ b/include/teb_local_planner/graph_search.h
@@ -90,9 +90,9 @@ typedef boost::graph_traits<HcGraph>::edge_iterator HcGraphEdgeIterator;
 typedef boost::graph_traits<HcGraph>::adjacency_iterator HcGraphAdjecencyIterator;
 
 //!< Inline function used for calculateHSignature() in combination with HCP graph vertex descriptors
-inline std::complex<long double> getCplxFromHcGraph(HcGraphVertexType vert_descriptor, const HcGraph& graph)
+inline EquivalenceClass::cplx getCplxFromHcGraph(HcGraphVertexType vert_descriptor, const HcGraph& graph)
 {
-  return std::complex<long double>(graph[vert_descriptor].pos.x(), graph[vert_descriptor].pos.y());
+  return EquivalenceClass::cplx(graph[vert_descriptor].pos.x(), graph[vert_descriptor].pos.y());
 }
 
 //!< Inline function used for initializing the TEB in combination with HCP graph vertex descriptors

--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -157,7 +157,7 @@ public:
                     cplx obst_j = obstacles->at(j)->getCentroidCplx();
                     cplx diff = obst_l - obst_j;
                     //if (diff.real()!=0 || diff.imag()!=0)
-                    if (std::abs(diff)<0.05) // skip really close obstacles
+                    if (std::norm(diff) < 0.05 * 0.05) // skip really close obstacles
                         continue;
                      else
                         Al /= diff;

--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -98,7 +98,7 @@ public:
     {
         if (obstacles->empty())
         {
-            hsignature_ = std::complex<double>(0,0);
+            hsignature_ = cplx(0,0);
             return;
         }
 
@@ -114,7 +114,6 @@ public:
 
         std::advance(path_end, -1); // reduce path_end by 1 (since we check line segments between those path points
 
-        typedef std::complex<long double> cplx;
         // guess map size (only a really really coarse guess is required
         // use distance from start to goal as distance to each direction
         // TODO: one could move the map determination outside this function, since it remains constant for the whole planning interval
@@ -230,13 +229,13 @@ public:
      * @brief Get the current value of the h-signature (read-only)
      * @return h-signature in complex-number format
      */
-     const std::complex<long double>& value() const {return hsignature_;}
+     const cplx& value() const {return hsignature_;}
 
 
 private:
 
     const TebConfig* cfg_;
-    std::complex<long double> hsignature_;
+    cplx hsignature_;
 };
 
 
@@ -299,8 +298,8 @@ public:
         // iterate path
         for (path_iter = path_start, timediff_iter = timediff_start.get(); path_iter != path_end; ++path_iter, ++timediff_iter)
         {
-          std::complex<long double> z1 = fun_cplx_point(*path_iter);
-          std::complex<long double> z2 = fun_cplx_point(*boost::next(path_iter));
+          cplx z1 = fun_cplx_point(*path_iter);
+          cplx z2 = fun_cplx_point(*boost::next(path_iter));
           Eigen::Vector2d pose (z1.real(), z1.imag());
           Eigen::Vector2d nextpose (z2.real(), z2.imag());
 

--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -147,8 +147,8 @@ public:
             for (std::size_t l=0; l<obstacles->size(); ++l) // iterate all obstacles
             {
                 cplx obst_l = obstacles->at(l)->getCentroidCplx();
-                //cplx f0 = (long double) prescaler * std::pow(obst_l-map_bottom_left,a) * std::pow(obst_l-map_top_right,b);
-                cplx f0 = (long double) cfg_->hcp.h_signature_prescaler * (long double)a*(obst_l-map_bottom_left) * (long double)b*(obst_l-map_top_right);
+                cplx f0 = (cplx::value_type) cfg_->hcp.h_signature_prescaler* std::pow(obst_l-map_bottom_left,a) * std::pow(obst_l-map_top_right,b);
+                //cplx f0 = (cplx::value_type) cfg_->hcp.h_signature_prescaler * (cplx::value_type)a*(obst_l-map_bottom_left) * (cplx::value_type)b*(obst_l-map_top_right);
 
                 // denum contains product with all obstacles exepct j==l
                 cplx Al = f0;

--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -136,8 +136,6 @@ public:
 
         hsignature_ = 0; // reset local signature
 
-        std::vector<double> imag_proposals(5);
-
         // iterate path
         while(path_start != path_end)
         {
@@ -164,22 +162,9 @@ public:
                      else
                         Al /= diff;
                 }
-                // compute log value
-                double diff2 = std::abs(z2-obst_l);
-                double diff1 = std::abs(z1-obst_l);
-                if (diff2 == 0 || diff1 == 0)
+                if (z1-obst_l == cplx(0, 0))
                     continue;
-                double log_real = std::log(diff2)-std::log(diff1);
-                // complex ln has more than one solution -> choose minimum abs angle -> paper
-                double arg_diff = std::arg(z2-obst_l)-std::arg(z1-obst_l);
-                imag_proposals.at(0) = arg_diff;
-                imag_proposals.at(1) = arg_diff+2*M_PI;
-                imag_proposals.at(2) = arg_diff-2*M_PI;
-                imag_proposals.at(3) = arg_diff+4*M_PI;
-                imag_proposals.at(4) = arg_diff-4*M_PI;
-                double log_imag = *std::min_element(imag_proposals.begin(),imag_proposals.end(),smaller_than_abs);
-                cplx log_value(log_real,log_imag);
-                //cplx log_value = std::log(z2-obst_l)-std::log(z1-obst_l); // the principal solution doesn't seem to work
+                cplx log_value(std::log((z2-obst_l) / (z1-obst_l)));
                 hsignature_ += Al*log_value;
             }
             ++path_start;

--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -145,8 +145,8 @@ public:
             for (std::size_t l=0; l<obstacles->size(); ++l) // iterate all obstacles
             {
                 cplx obst_l = obstacles->at(l)->getCentroidCplx();
-                cplx f0 = (cplx::value_type) cfg_->hcp.h_signature_prescaler* std::pow(obst_l-map_bottom_left,a) * std::pow(obst_l-map_top_right,b);
-                //cplx f0 = (cplx::value_type) cfg_->hcp.h_signature_prescaler * (cplx::value_type)a*(obst_l-map_bottom_left) * (cplx::value_type)b*(obst_l-map_top_right);
+                //cplx f0 = (cplx::value_type) cfg_->hcp.h_signature_prescaler* std::pow(obst_l-map_bottom_left,a) * std::pow(obst_l-map_top_right,b);
+                cplx f0 = (cplx::value_type) cfg_->hcp.h_signature_prescaler * (cplx::value_type)a*(obst_l-map_bottom_left) * (cplx::value_type)b*(obst_l-map_top_right);
 
                 // denum contains product with all obstacles exepct j==l
                 cplx Al = f0;
@@ -158,9 +158,9 @@ public:
                     cplx diff = obst_l - obst_j;
                     //if (diff.real()!=0 || diff.imag()!=0)
                     if (std::norm(diff) < 0.05 * 0.05) // skip really close obstacles
-                        continue;
-                     else
                         Al /= diff;
+                     else
+                        continue;
                 }
                 if (z1-obst_l == cplx(0, 0))
                     continue;

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -68,16 +68,16 @@ namespace teb_local_planner
 {
 
 //!< Inline function used for calculateHSignature() in combination with VertexPose pointers
-inline std::complex<long double> getCplxFromVertexPosePtr(const VertexPose* pose)
+inline EquivalenceClass::cplx getCplxFromVertexPosePtr(const VertexPose* pose)
 {
-  return std::complex<long double>(pose->x(), pose->y());
+  return EquivalenceClass::cplx(pose->x(), pose->y());
 };
 
 
 //!< Inline function used for calculateHSignature() in combination with geometry_msgs::PoseStamped
-inline std::complex<long double> getCplxFromMsgPoseStamped(const geometry_msgs::PoseStamped& pose)
+inline EquivalenceClass::cplx getCplxFromMsgPoseStamped(const geometry_msgs::PoseStamped& pose)
 {
-  return std::complex<long double>(pose.pose.position.x, pose.pose.position.y);
+  return EquivalenceClass::cplx(pose.pose.position.x, pose.pose.position.y);
 };
 
 /**
@@ -419,7 +419,7 @@ public:
    * @param h2 second h-signature
    * @return \c true if both h-signatures are similar, false otherwise.
    */
-  inline static bool isHSignatureSimilar(const std::complex<long double>& h1, const std::complex<long double>& h2, double threshold)
+  inline static bool isHSignatureSimilar(const EquivalenceClass::cplx& h1, const EquivalenceClass::cplx& h2, double threshold)
   {
       double diff_real = std::abs(h2.real() - h1.real());
       double diff_imag = std::abs(h2.imag() - h1.imag());


### PR DESCRIPTION
An upstream bugfix to the denominator portion of Al caused all
H-signatures to be so close to zero as to be considered identical.
Restoring a previous, bigger numerator calculation to fix it but makes
the calculation much slower than before. So, we ultimately revert to the
way it was to before the fix to the denominator which, while
not matching the theorem, worked OK in practice and performed about 4
times faster.

Also made a couple of minor performance improvements and made consistent
use of the cplx typedef.

* 2540f33 h_signature: Undo recent changes for speed
* ccf0bf6 h_signature: Tiny performance improvement
* 3afaf87 h_signature: Simplify calculation of log_value
* 9bb9cf5 h_signature: Revert to power function for f0 (numerator)
* a1ec2e2 h_signature: Use cplx typedef consistently

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/teb_local_planner/7)
<!-- Reviewable:end -->
