### PR TITLE
add optional left-right obstacle inflation edges

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -196,6 +196,24 @@ grp_obstacles.add("inflation_dist", double_t, 0,
         "Buffer zone around obstacles with non-zero penalty costs (should be larger than min_obstacle_dist in order to take effect)",
         0.6, 0, 15)
 
+grp_obstacles.add("left_inflation_dist", double_t, 0,
+        "Buffer zone around obstacles to the left of the pose with non-zero penalty costs "
+        "(should be larger than min_obstacle_dist in order to take effect). "
+        "Setting the left/right inflation to different values allows a preference to driving on one side of a hallway. "
+        "Note that setting this currently only works with Costmap3D queries, "
+        "and causes two additional query edges to be added to the graph for "
+        "left/right for the poses allowed by first_left_right_pose and last_left_right_pose.",
+        0.0, 0, 15)
+
+grp_obstacles.add("right_inflation_dist", double_t, 0,
+        "Buffer zone around obstacles to the right of the pose with non-zero penalty costs "
+        "(should be larger than min_obstacle_dist in order to take effect). "
+        "Setting the left/right inflation to different values allows a preference to driving on one side of a hallway. "
+        "Note that setting this currently only works with Costmap3D queries, "
+        "and causes two additional query edges to be added to the graph for "
+        "left/right for the poses allowed by first_left_right_pose and last_left_right_pose.",
+        0.0, 0, 15)
+
 grp_obstacles.add("dynamic_obstacle_inflation_dist", double_t, 0,
         "Buffer zone around predicted locations of dynamic obstacles with non-zero penalty costs (should be larger than min_obstacle_dist in order to take effect)",
         0.6, 0, 15)
@@ -227,6 +245,26 @@ grp_obstacles.add("costmap_obstacles_behind_robot_dist",   double_t,   0,
 grp_obstacles.add("obstacle_poses_affected",    int_t,    0, 
 	"The obstacle position is attached to the closest pose on the trajectory to reduce computational effort, but take a number of neighbors into account as well", 
 	30, 0, 200)
+
+grp_obstacles.add("first_left_right_pose", int_t, 0,
+        "First pose index on which to add left/right obstacle edges. "
+        "Negative numbers are indexed from the last pose. "
+        "This helps reduce CPU load when in costmap 3D mode, "
+        "as left/right queries are more expensive.",
+        0, -100, 100)
+
+grp_obstacles.add("last_left_right_pose", int_t, 0,
+        "Last pose index on which to add left/right obstacle edges. "
+        "Negative numbers are indexed from the last pose. "
+        "This helps reduce CPU load when in costmap 3D mode, "
+        "as left/right queries are more expensive.",
+        -1, -100, 100)
+
+grp_obstacles.add("left_right_skip_poses", int_t, 0,
+        "Skip this many poses between adding left/right edges. "
+        "This helps reduce CPU load when in costmap 3D mode, "
+        "as left/right queries are more expensive.",
+        0, 0, 20)
 	
 
 # Optimization
@@ -327,6 +365,18 @@ grp_optimization.add("obstacle_cost_exponent", double_t, 0,
 grp_optimization.add("inflation_cost_exponent", double_t, 0,
 	"Exponent for nonlinear obstacle inflation cost (cost = inflation_dist * pow([fraction of possible inflation_cost], inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)",
 	1, 0.01, 100)
+
+grp_optimization.add("weight_left_right_inflation", double_t, 0,
+        "Optimization weight for the left/right inflation penalty (should be small)",
+        1.0, 0, 100)
+
+grp_optimization.add("left_inflation_cost_exponent", double_t, 0,
+        "Exponent for nonlinear left obstacle inflation cost (cost = left_inflation_dist * pow([fraction of possible inflation_cost], left_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)",
+        1, 0.01, 100)
+
+grp_optimization.add("right_inflation_cost_exponent", double_t, 0,
+        "Exponent for nonlinear right obstacle inflation cost (cost = right_inflation_dist * pow([fraction of possible inflation_cost], right_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)",
+        1, 0.01, 100)
   
   
 # Homotopy Class Planner

--- a/include/teb_local_planner/g2o_types/edge_3d_costmap.h
+++ b/include/teb_local_planner/g2o_types/edge_3d_costmap.h
@@ -103,7 +103,7 @@ public:
     }
 
     _error[1] = penaltyBoundFromBelow(dist, cfg_->obstacles.inflation_dist, 0.0);
-    if (cfg_->optim.inflation_cost_exponent != 1.0 && cfg_->obstacles.inflation_dist > 0.0)
+    if (cfg_->optim.inflation_cost_exponent != 1.0 && cfg_->obstacles.inflation_dist > 0.0 && dist >= 0.0)
     {
       // Optional non-linear inflation cost. See comment above about obstacle_cost_exponent.
       _error[1] = cfg_->obstacles.inflation_dist * std::pow(_error[1] / cfg_->obstacles.inflation_dist, cfg_->optim.inflation_cost_exponent);

--- a/include/teb_local_planner/g2o_types/edge_3d_costmap_left_right.h
+++ b/include/teb_local_planner/g2o_types/edge_3d_costmap_left_right.h
@@ -1,0 +1,161 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019 Badger Technologies LLC
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the institute nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Notes:
+ * The following class is derived from a class defined by the
+ * g2o-framework. g2o is licensed under the terms of the BSD License.
+ * Refer to the base class source for detailed licensing information.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef EDGE_3D_COSTMAP_LEFT_RIGHT_H_
+#define EDGE_3D_COSTMAP_LEFT_RIGHT_H_
+
+#include <teb_local_planner/g2o_types/vertex_pose.h>
+#include <teb_local_planner/g2o_types/base_teb_edges.h>
+#include <teb_local_planner/g2o_types/penalties.h>
+
+// costmap 3d
+#include <costmap_3d/costmap_3d_query.h>
+
+namespace teb_local_planner
+{
+
+/**
+ * @class Edge3DCostmapLeftRight
+ * @brief Edge defining the cost function for inflating obstacles that are
+ *        only left or right of the pose.
+ */
+class Edge3DCostmapLeftRight : public BaseTebUnaryEdge<1, const void *, VertexPose>
+{
+public:
+
+  /**
+   * @brief Construct edge.
+   */
+  Edge3DCostmapLeftRight()
+  {
+  }
+
+  /**
+   * @brief Construct edge.
+   */
+  Edge3DCostmapLeftRight(costmap_3d::Costmap3DQueryPtr costmap_3d_query,
+                         bool is_left,
+                         double inflation_dist,
+                         double inflation_cost_exponent)
+      : costmap_3d_query_(costmap_3d_query),
+        inflation_dist_(inflation_dist),
+        inflation_cost_exponent_(inflation_cost_exponent),
+        region_(is_left ? costmap_3d::Costmap3DQuery::LEFT : costmap_3d::Costmap3DQuery::RIGHT)
+  {
+  }
+
+  inline void computeErrorImpl(bool reuse_results=false)
+  {
+    const VertexPose* vertex_pose = static_cast<const VertexPose*>(_vertices[0]);
+    geometry_msgs::Pose pose_msg;
+    vertex_pose->pose().toPoseMsg(pose_msg);
+
+    double dist = costmap_3d_query_->footprintDistance(pose_msg, region_, reuse_results);
+
+    // For left/right edges, make derivative zero inside the region normal
+    // obstacles have influence. This prevents destabalizing a TeB that must
+    // go near an obstacle.
+    if (dist < cfg_->obstacles.min_obstacle_dist)
+      dist = cfg_->obstacles.min_obstacle_dist;
+
+    _error[0] = penaltyBoundFromBelow(dist, inflation_dist_, 0.0);
+    if (inflation_cost_exponent_ != 1.0 && inflation_dist_ > 0.0 && dist >= 0.0)
+    {
+      // Optional non-linear cost.
+      _error[0] = inflation_dist_ * std::pow(_error[0] / inflation_dist_, inflation_cost_exponent_);
+    }
+
+    ROS_ASSERT_MSG(std::isfinite(_error[0]), "Edge3DCostmapLeftRight::computeError() _error[0]=%f\n",_error[0]);
+  }
+
+  void computeError()
+  {
+    computeErrorImpl();
+  }
+
+  virtual void linearizeOplus()
+  {
+    //Xi - estimate the jacobian numerically
+    VertexPose* vi = static_cast<VertexPose*>(_vertices[0]);
+
+    if (vi->fixed())
+      return;
+
+#ifdef G2O_OPENMP
+    vi->lockQuadraticForm();
+#endif
+
+    const double delta = 1e-5;
+    const double scalar = 1.0 / (delta);
+    // calculate the derivative to the base pose each time, reducing total queries
+    computeError();
+    ErrorVector errorBeforeNumeric = _error;
+
+    double add_vi[VertexPose::Dimension];
+    std::fill(add_vi, add_vi + VertexPose::Dimension, 0.0);
+    // add small step along the unit vector in each dimension
+    for (int d = 0; d < VertexPose::Dimension; ++d) {
+      vi->push();
+      add_vi[d] = delta;
+      vi->oplus(add_vi);
+      // reuse the previous calculation to save time estimating the derivative
+      computeErrorImpl(true);
+      vi->pop();
+      add_vi[d] = 0.0;
+
+      _jacobianOplusXi.col(d) = scalar * (_error - errorBeforeNumeric);
+    } // end dimension
+    _error = errorBeforeNumeric;
+  }
+
+protected:
+  costmap_3d::Costmap3DQueryPtr costmap_3d_query_;
+  double inflation_dist_;
+  double inflation_cost_exponent_;
+  costmap_3d::Costmap3DQuery::QueryRegion region_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+};
+
+} // end namespace
+
+#endif

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -70,6 +70,7 @@
 #include <teb_local_planner/g2o_types/edge_via_point.h>
 #include <teb_local_planner/g2o_types/edge_prefer_rotdir.h>
 #include <teb_local_planner/g2o_types/edge_3d_costmap.h>
+#include <teb_local_planner/g2o_types/edge_3d_costmap_left_right.h>
 
 // messages
 #include <nav_msgs/Path.h>
@@ -662,6 +663,11 @@ protected:
    * @brief Add edges to query the costmap 3D directly.
    */
   void AddEdges3DCostmap(double weight_multiplier=1.0);
+
+  /**
+   * @brief Add 3D costmap edges to inflate obstacles that are left/right
+   */
+  void AddEdges3DCostmapLeftRight();
 
   /**
    * @brief Add all edges (local cost functions) related to minimizing the distance to via-points

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -127,6 +127,8 @@ public:
   {
     double min_obstacle_dist; //!< Minimum desired separation from obstacles
     double inflation_dist; //!< buffer zone around obstacles with non-zero penalty costs (should be larger than min_obstacle_dist in order to take effect)
+    double left_inflation_dist; //!< buffer zone around obstacles to the left with non-zero penalty costs (should be larger than min_obstacle_dist in order to take effect)
+    double right_inflation_dist; //!< buffer zone around obstacles to the right with non-zero penalty costs (should be larger than min_obstacle_dist in order to take effect)
     double dynamic_obstacle_inflation_dist; //!< Buffer zone around predicted locations of dynamic obstacles with non-zero penalty costs (should be larger than min_obstacle_dist in order to take effect)
     bool include_dynamic_obstacles; //!< Specify whether the movement of dynamic obstacles should be predicted by a constant velocity model (this also effects homotopy class planning); If false, all obstacles are considered to be static.
     bool include_costmap_obstacles; //!< Specify whether the obstacles in the costmap should be taken into account directly
@@ -139,6 +141,9 @@ public:
     std::string costmap_converter_plugin; //!< Define a plugin name of the costmap_converter package (costmap cells are converted to points/lines/polygons)
     bool costmap_converter_spin_thread; //!< If \c true, the costmap converter invokes its callback queue in a different thread
     int costmap_converter_rate; //!< The rate that defines how often the costmap_converter plugin processes the current costmap (the value should not be much higher than the costmap update rate)
+    int first_left_right_pose; //!< First pose to attach left/right edges.
+    int last_left_right_pose; //!< Last pose to attach left/right edges.
+    int left_right_skip_poses; //!< Skip this many poses when adding left/right edges
   } obstacles; //!< Obstacle related parameters
 
 
@@ -174,6 +179,9 @@ public:
     double weight_adapt_factor; //!< Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new = weight_old*factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.
     double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = min_obstacle_dist * pow([fraction of possible linear_cost], obstacle_cost_exponent)). Set to 1 to disable nonlinear cost (default)
     double inflation_cost_exponent; //!< Exponent for nonlinear obstacle inflation cost (cost = inflation_dist * pow([fraction of possible inflation_cost], inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)
+    double weight_left_right_inflation; //!< Optimization weight for the left/right inflation penalty (should be small)
+    double left_inflation_cost_exponent; //!< Exponent for nonlinear left obstacle inflation cost (cost = left_inflation_dist * pow([fraction of possible inflation_cost], left_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)
+    double right_inflation_cost_exponent; //!< Exponent for nonlinear right obstacle inflation cost (cost = right_inflation_dist * pow([fraction of possible inflation_cost], right_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)
   } optim; //!< Optimization related parameters
 
 
@@ -305,6 +313,8 @@ public:
 
     obstacles.min_obstacle_dist = 0.5;
     obstacles.inflation_dist = 0.6;
+    obstacles.left_inflation_dist = 0.0;
+    obstacles.right_inflation_dist = 0.0;
     obstacles.dynamic_obstacle_inflation_dist = 0.6;
     obstacles.include_dynamic_obstacles = true;
     obstacles.include_costmap_obstacles = true;
@@ -317,6 +327,9 @@ public:
     obstacles.costmap_converter_plugin = "";
     obstacles.costmap_converter_spin_thread = true;
     obstacles.costmap_converter_rate = 5;
+    obstacles.first_left_right_pose = 0;
+    obstacles.last_left_right_pose = 0;
+    obstacles.left_right_skip_poses = 0;
 
     // Optimization
 
@@ -346,6 +359,9 @@ public:
     optim.weight_adapt_factor = 2.0;
     optim.obstacle_cost_exponent = 1.0;
     optim.inflation_cost_exponent = 1.0;
+    optim.weight_left_right_inflation = 1.0;
+    optim.left_inflation_cost_exponent = 1.0;
+    optim.right_inflation_cost_exponent = 1.0;
 
     // Homotopy Class Planner
 

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -364,6 +364,7 @@ protected:
   costmap_2d::Costmap2DROS* costmap_ros_; //!< Pointer to the costmap ros wrapper, received from the navigation stack
   costmap_3d::Costmap3DROS* costmap_3d_ros_; //!< Pointer to the costmap 3D ros wrapper, if use_costmap_3d and costmap is actually 3D
   costmap_2d::Costmap2D* costmap_; //!< Pointer to the 2d costmap (obtained from the costmap ros wrapper)
+  costmap_3d::Costmap3DQueryPtr costmap_3d_query_; //!< Pointer to the costmap 3D query, if use_costmap_3d and costmap is actually 3D
   tf::TransformListener* tf_; //!< pointer to Transform Listener
     
   // internal objects (memory management owned)

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -483,6 +483,8 @@ bool TebOptimalPlanner::buildGraph(double weight_multiplier)
     AddEdgesDynamicObstacles();
 
   AddEdges3DCostmap(weight_multiplier);
+
+  AddEdges3DCostmapLeftRight();
   
   AddEdgesViaPoints();
   
@@ -1054,6 +1056,59 @@ void TebOptimalPlanner::AddEdges3DCostmap(double weight_multiplier)
     edge->setTebConfig(*cfg_);
     optimizer_->addEdge(edge);
   }
+}
+
+void TebOptimalPlanner::AddEdges3DCostmapLeftRight()
+{
+  if (!costmap_3d_query_)
+    return;
+
+  // Nothing to do when the final result will always be zero
+  if (cfg_->optim.weight_left_right_inflation == 0.0)
+    return;
+
+  int first_pose = cfg_->obstacles.first_left_right_pose;
+  int last_pose = cfg_->obstacles.last_left_right_pose;
+  int step_count = cfg_->obstacles.left_right_skip_poses + 1;
+  Eigen::Matrix<double,1,1> information;
+  information(0,0) = cfg_->optim.weight_left_right_inflation;
+
+  // First index from the end for negative indices
+  first_pose = (first_pose < 0 ? teb_.sizePoses() + first_pose : first_pose);
+  last_pose = (last_pose < 0 ? teb_.sizePoses() + last_pose : last_pose);
+
+  // Now clamp the first/last indices to the appropriate vertices
+  first_pose = std::max(first_pose, 1);
+  last_pose = std::min(last_pose, teb_.sizePoses()-2);
+
+  auto addLeftRightEdge = [this, information](bool is_left,
+                                              int i,
+                                              double inflation_dist,
+                                              double inflation_cost_exponent)
+  {
+    Edge3DCostmapLeftRight* edge = new Edge3DCostmapLeftRight(this->costmap_3d_query_,
+                                                              is_left,
+                                                              inflation_dist,
+                                                              inflation_cost_exponent);
+    edge->setVertex(0, this->teb_.PoseVertex(i));
+    edge->setInformation(information);
+    edge->setTebConfig(*this->cfg_);
+    this->optimizer_->addEdge(edge);
+  };
+
+  if (cfg_->obstacles.left_inflation_dist > cfg_->obstacles.min_obstacle_dist)
+    for (int i = first_pose; i <= last_pose; i += step_count)
+      addLeftRightEdge(true,
+                       i,
+                       cfg_->obstacles.left_inflation_dist,
+                       cfg_->optim.left_inflation_cost_exponent);
+
+  if (cfg_->obstacles.right_inflation_dist > cfg_->obstacles.min_obstacle_dist)
+    for (int i = first_pose; i <= last_pose; i += step_count)
+      addLeftRightEdge(false,
+                       i,
+                       cfg_->obstacles.right_inflation_dist,
+                       cfg_->optim.right_inflation_cost_exponent);
 }
 
 void TebOptimalPlanner::AddEdgesTimeOptimal()

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -97,6 +97,8 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   // Obstacles
   nh.param("min_obstacle_dist", obstacles.min_obstacle_dist, obstacles.min_obstacle_dist);
   nh.param("inflation_dist", obstacles.inflation_dist, obstacles.inflation_dist);
+  nh.param("left_inflation_dist", obstacles.left_inflation_dist, obstacles.left_inflation_dist);
+  nh.param("right_inflation_dist", obstacles.right_inflation_dist, obstacles.right_inflation_dist);
   nh.param("dynamic_obstacle_inflation_dist", obstacles.dynamic_obstacle_inflation_dist, obstacles.dynamic_obstacle_inflation_dist);
   nh.param("include_dynamic_obstacles", obstacles.include_dynamic_obstacles, obstacles.include_dynamic_obstacles);
   nh.param("include_costmap_obstacles", obstacles.include_costmap_obstacles, obstacles.include_costmap_obstacles);
@@ -109,6 +111,9 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("costmap_converter_plugin", obstacles.costmap_converter_plugin, obstacles.costmap_converter_plugin);
   nh.param("costmap_converter_spin_thread", obstacles.costmap_converter_spin_thread, obstacles.costmap_converter_spin_thread);
   nh.param("costmap_converter_rate", obstacles.costmap_converter_rate, obstacles.costmap_converter_rate);
+  nh.param("first_left_right_pose", obstacles.first_left_right_pose, obstacles.first_left_right_pose);
+  nh.param("last_left_right_pose", obstacles.last_left_right_pose, obstacles.last_left_right_pose);
+  nh.param("left_right_skip_poses", obstacles.left_right_skip_poses, obstacles.left_right_skip_poses);
   
   // Optimization
   nh.param("no_inner_iterations", optim.no_inner_iterations, optim.no_inner_iterations);
@@ -136,6 +141,9 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
   nh.param("obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
   nh.param("inflation_cost_exponent", optim.inflation_cost_exponent, optim.inflation_cost_exponent);
+  nh.param("weight_left_right_inflation", optim.weight_left_right_inflation, optim.weight_left_right_inflation);
+  nh.param("left_inflation_cost_exponent", optim.left_inflation_cost_exponent, optim.left_inflation_cost_exponent);
+  nh.param("right_inflation_cost_exponent", optim.right_inflation_cost_exponent, optim.right_inflation_cost_exponent);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -237,6 +245,8 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   // Obstacles
   obstacles.min_obstacle_dist = cfg.min_obstacle_dist;
   obstacles.inflation_dist = cfg.inflation_dist;
+  obstacles.left_inflation_dist = cfg.left_inflation_dist;
+  obstacles.right_inflation_dist = cfg.right_inflation_dist;
   obstacles.dynamic_obstacle_inflation_dist = cfg.dynamic_obstacle_inflation_dist;
   obstacles.include_dynamic_obstacles = cfg.include_dynamic_obstacles;
   obstacles.include_costmap_obstacles = cfg.include_costmap_obstacles;
@@ -245,6 +255,9 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   obstacles.obstacle_association_cutoff_factor = cfg.obstacle_association_cutoff_factor;
   obstacles.costmap_obstacles_behind_robot_dist = cfg.costmap_obstacles_behind_robot_dist;
   obstacles.obstacle_poses_affected = cfg.obstacle_poses_affected;
+  obstacles.first_left_right_pose = cfg.first_left_right_pose;
+  obstacles.last_left_right_pose = cfg.last_left_right_pose;
+  obstacles.left_right_skip_poses = cfg.left_right_skip_poses;
 
   
   // Optimization
@@ -272,6 +285,9 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;
   optim.inflation_cost_exponent = cfg.inflation_cost_exponent;
+  optim.weight_left_right_inflation = cfg.weight_left_right_inflation;
+  optim.left_inflation_cost_exponent = cfg.left_inflation_cost_exponent;
+  optim.right_inflation_cost_exponent = cfg.right_inflation_cost_exponent;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -137,10 +137,14 @@ void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf,
     if (costmap_3d_ros_ != nullptr)
     {
       ROS_INFO("Using Costmap3DROS");
-      // Override the costmap model with a Costmap3DModel
-      costmap_model_ = boost::make_shared<base_local_planner::Costmap3DModel>(*costmap_3d_ros_);
       // Tell the planner to use a 3D costmap query that tracks the current costmap for obstacles
-      planner_->useCostmap3DQuery(costmap_3d_ros_->getAssociatedQuery());
+      costmap_3d_query_ = costmap_3d_ros_->getBufferedQuery();
+      planner_->useCostmap3DQuery(costmap_3d_query_);
+      // Override the costmap model with a Costmap3DModel
+      auto costmap_3d_model = boost::make_shared<base_local_planner::Costmap3DModel>(*costmap_3d_ros_);
+      // Override the default associated query in the model with our buffered query
+      costmap_3d_model->setQuery(costmap_3d_query_);
+      costmap_model_ = costmap_3d_model;
     }
 
     //Initialize a costmap to polygon converter
@@ -337,6 +341,9 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   else
     updateObstacleContainerWithCostmap();
   
+  // update costmap 3D query
+  costmap_3d_ros_->updateBufferedQuery(costmap_3d_query_);
+
   // also consider custom obstacles (must be called after other updates, since the container is not cleared)
   updateObstacleContainerWithCustomObstacles();
   


### PR DESCRIPTION
Add ability to optionally add left-right inflation edges to one or
more of the pose verteces. The left-right edges are inflation-only
edges where only obstacles to the left or right are taken into
account. The starting and stopping pose vertex are configurable, as
is the pose skip for adding edges. Also, the left and right exponents
and inflation distances are separate so an asymetry can be created
that is useful to cause the base to navigate on one side or other of
a corridor or aisle.

Currently this is only implemented when using Costmap3D.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/teb_local_planner/10)
<!-- Reviewable:end -->
