### PR TITLE
add edges for nonlethal obstacles

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -265,6 +265,10 @@ grp_obstacles.add("left_right_skip_poses", int_t, 0,
         "This helps reduce CPU load when in costmap 3D mode, "
         "as left/right queries are more expensive.",
         0, 0, 20)
+
+grp_obstacles.add("min_nonlethal_obstacle_dist", double_t, 0,
+	"Minimum desired separation from non-lethal obstacles",
+	0.1, 0, 10)
 	
 
 # Optimization
@@ -376,6 +380,14 @@ grp_optimization.add("left_inflation_cost_exponent", double_t, 0,
 
 grp_optimization.add("right_inflation_cost_exponent", double_t, 0,
         "Exponent for nonlinear right obstacle inflation cost (cost = right_inflation_dist * pow([fraction of possible inflation_cost], right_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)",
+        1, 0.01, 100)
+
+grp_optimization.add("weight_nonlethal_obstacle", double_t, 0,
+        "Optimization weight for a seprataion from non-lethal obstacles (0 to disable)",
+        1, 0, 100)
+
+grp_optimization.add("nonlethal_obstacle_cost_exponent", double_t, 0,
+        "Exponent for nonlinear, non-lethal obstacle cost",
         1, 0.01, 100)
   
   

--- a/include/teb_local_planner/g2o_types/edge_3d_costmap_nonlethal_only.h
+++ b/include/teb_local_planner/g2o_types/edge_3d_costmap_nonlethal_only.h
@@ -1,0 +1,158 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019 Badger Technologies LLC
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the institute nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Notes:
+ * The following class is derived from a class defined by the
+ * g2o-framework. g2o is licensed under the terms of the BSD License.
+ * Refer to the base class source for detailed licensing information.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef EDGE_3D_COSTMAP_NONLETHAL_H_
+#define EDGE_3D_COSTMAP_NONLETHAL_H_
+
+#include <teb_local_planner/g2o_types/vertex_pose.h>
+#include <teb_local_planner/g2o_types/base_teb_edges.h>
+#include <teb_local_planner/g2o_types/penalties.h>
+
+// costmap 3d
+#include <costmap_3d/costmap_3d_query.h>
+
+namespace teb_local_planner
+{
+
+/**
+ * @class Edge3DCostmapNonlethalOnly
+ * @brief Edge defining the cost function for navigating around nonlethal only
+ *        obstacles (detected objects that are not considered lethal) using
+ *        distance queries on a 3D costmap.
+ */
+class Edge3DCostmapNonlethalOnly : public BaseTebUnaryEdge<1, const void *, VertexPose>
+{
+public:
+
+  /**
+   * @brief Construct edge.
+   */
+  Edge3DCostmapNonlethalOnly()
+  {
+  }
+
+  /**
+   * @brief Construct edge.
+   */
+  Edge3DCostmapNonlethalOnly(costmap_3d::Costmap3DQueryPtr costmap_3d_query,
+                             double obstacle_dist,
+                             double obstacle_cost_exponent)
+  {
+    costmap_3d_query_ = costmap_3d_query;
+    min_obstacle_dist_ = obstacle_dist;
+    obstacle_cost_exponent_ = obstacle_cost_exponent;
+  }
+
+  inline void computeErrorImpl(bool reuse_results=false)
+  {
+    const VertexPose* vertex_pose = static_cast<const VertexPose*>(_vertices[0]);
+    geometry_msgs::Pose pose_msg;
+    vertex_pose->pose().toPoseMsg(pose_msg);
+
+    costmap_3d::Costmap3DQuery::DistanceOptions dopts;
+    dopts.reuse_past_result = reuse_results;
+    dopts.signed_distance = true;
+    dopts.query_obstacles = costmap_3d::Costmap3DQuery::NONLETHAL_ONLY;
+    double signed_dist = costmap_3d_query_->footprintDistance(pose_msg, dopts);
+
+    _error[0] = penaltyBoundFromBelow(signed_dist, min_obstacle_dist_, 0.0);
+
+    if (obstacle_cost_exponent_ != 1.0 && min_obstacle_dist_ > 0.0 && signed_dist >= 0.0)
+    {
+      // Optional non-linear cost.
+      _error[0] = min_obstacle_dist_ * std::pow(_error[0] / min_obstacle_dist_, obstacle_cost_exponent_);
+    }
+
+    ROS_ASSERT_MSG(std::isfinite(_error[0]), "Edge3DCostmapNonlethalOnly::computeError() _error[0]=%f\n",_error[0]);
+  }
+
+  void computeError()
+  {
+    return computeErrorImpl();
+  }
+
+  virtual void linearizeOplus()
+  {
+    //Xi - estimate the jacobian numerically
+    VertexPose* vi = static_cast<VertexPose*>(_vertices[0]);
+
+    if (vi->fixed())
+      return;
+
+#ifdef G2O_OPENMP
+    vi->lockQuadraticForm();
+#endif
+
+    const double delta = 1e-5;
+    const double scalar = 1.0 / (delta);
+    // calculate the derivative to the base pose each time, reducing total queries
+    computeError();
+    ErrorVector errorBeforeNumeric = _error;
+
+    double add_vi[VertexPose::Dimension];
+    std::fill(add_vi, add_vi + VertexPose::Dimension, 0.0);
+    // add small step along the unit vector in each dimension
+    for (int d = 0; d < VertexPose::Dimension; ++d) {
+      vi->push();
+      add_vi[d] = delta;
+      vi->oplus(add_vi);
+      // reuse the previous calculation to save time estimating the derivative
+      computeErrorImpl(true);
+      vi->pop();
+      add_vi[d] = 0.0;
+
+      _jacobianOplusXi.col(d) = scalar * (_error - errorBeforeNumeric);
+    } // end dimension
+    _error = errorBeforeNumeric;
+  }
+
+protected:
+  costmap_3d::Costmap3DQueryPtr costmap_3d_query_;
+  double min_obstacle_dist_;
+  double obstacle_cost_exponent_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+};
+
+}  // namespace teb_local_planner
+
+#endif  // EDGE_3D_COSTMAP_NONLETHAL_H_

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -71,6 +71,7 @@
 #include <teb_local_planner/g2o_types/edge_prefer_rotdir.h>
 #include <teb_local_planner/g2o_types/edge_3d_costmap.h>
 #include <teb_local_planner/g2o_types/edge_3d_costmap_left_right.h>
+#include <teb_local_planner/g2o_types/edge_3d_costmap_nonlethal_only.h>
 
 // messages
 #include <nav_msgs/Path.h>
@@ -668,6 +669,11 @@ protected:
    * @brief Add 3D costmap edges to inflate obstacles that are left/right
    */
   void AddEdges3DCostmapLeftRight();
+
+  /**
+   * @brief Add 3D costmap edges for nonlethal obstacles
+   */
+  void AddEdges3DCostmapNonlethalOnly();
 
   /**
    * @brief Add all edges (local cost functions) related to minimizing the distance to via-points

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -144,6 +144,7 @@ public:
     int first_left_right_pose; //!< First pose to attach left/right edges.
     int last_left_right_pose; //!< Last pose to attach left/right edges.
     int left_right_skip_poses; //!< Skip this many poses when adding left/right edges
+    double min_nonlethal_obstacle_dist; //!< Minimum desired separation from non-lethal obstacles
   } obstacles; //!< Obstacle related parameters
 
 
@@ -182,6 +183,8 @@ public:
     double weight_left_right_inflation; //!< Optimization weight for the left/right inflation penalty (should be small)
     double left_inflation_cost_exponent; //!< Exponent for nonlinear left obstacle inflation cost (cost = left_inflation_dist * pow([fraction of possible inflation_cost], left_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)
     double right_inflation_cost_exponent; //!< Exponent for nonlinear right obstacle inflation cost (cost = right_inflation_dist * pow([fraction of possible inflation_cost], right_inflation_cost_exponent)). Set to 1 to disable nonlinear cost (default)
+    double weight_nonlethal_obstacle; //!< Optimization weight for non-lethal obstacles (obstacles that are sensed but not lethal)
+    double nonlethal_obstacle_cost_exponent; //!< Exponent for nonlinear, nonlethal obstacle cost
   } optim; //!< Optimization related parameters
 
 
@@ -330,6 +333,7 @@ public:
     obstacles.first_left_right_pose = 0;
     obstacles.last_left_right_pose = 0;
     obstacles.left_right_skip_poses = 0;
+    obstacles.min_nonlethal_obstacle_dist = 0.1;
 
     // Optimization
 
@@ -362,6 +366,8 @@ public:
     optim.weight_left_right_inflation = 1.0;
     optim.left_inflation_cost_exponent = 1.0;
     optim.right_inflation_cost_exponent = 1.0;
+    optim.weight_nonlethal_obstacle = 1.0;
+    optim.nonlethal_obstacle_cost_exponent = 1.0;
 
     // Homotopy Class Planner
 

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -114,6 +114,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("first_left_right_pose", obstacles.first_left_right_pose, obstacles.first_left_right_pose);
   nh.param("last_left_right_pose", obstacles.last_left_right_pose, obstacles.last_left_right_pose);
   nh.param("left_right_skip_poses", obstacles.left_right_skip_poses, obstacles.left_right_skip_poses);
+  nh.param("min_nonlethal_obstacle_dist", obstacles.min_nonlethal_obstacle_dist, obstacles.min_nonlethal_obstacle_dist);
   
   // Optimization
   nh.param("no_inner_iterations", optim.no_inner_iterations, optim.no_inner_iterations);
@@ -144,6 +145,8 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_left_right_inflation", optim.weight_left_right_inflation, optim.weight_left_right_inflation);
   nh.param("left_inflation_cost_exponent", optim.left_inflation_cost_exponent, optim.left_inflation_cost_exponent);
   nh.param("right_inflation_cost_exponent", optim.right_inflation_cost_exponent, optim.right_inflation_cost_exponent);
+  nh.param("weight_nonlethal_obstacle", optim.weight_nonlethal_obstacle, optim.weight_nonlethal_obstacle);
+  nh.param("nonlethal_obstacle_cost_exponent", optim.nonlethal_obstacle_cost_exponent, optim.nonlethal_obstacle_cost_exponent);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -258,6 +261,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   obstacles.first_left_right_pose = cfg.first_left_right_pose;
   obstacles.last_left_right_pose = cfg.last_left_right_pose;
   obstacles.left_right_skip_poses = cfg.left_right_skip_poses;
+  obstacles.min_nonlethal_obstacle_dist = cfg.min_nonlethal_obstacle_dist;
 
   
   // Optimization
@@ -288,6 +292,8 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_left_right_inflation = cfg.weight_left_right_inflation;
   optim.left_inflation_cost_exponent = cfg.left_inflation_cost_exponent;
   optim.right_inflation_cost_exponent = cfg.right_inflation_cost_exponent;
+  optim.weight_nonlethal_obstacle = cfg.weight_nonlethal_obstacle;
+  optim.nonlethal_obstacle_cost_exponent = cfg.nonlethal_obstacle_cost_exponent;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;


### PR DESCRIPTION
Costmaps can track obstacles that are inbetween the cost of free
space and lethal space. This can be useful when an object is detected,
such as a cord on the floor or a mat, that can be safely navigated,
but is better to be avoided if possible.

Add options to add edges for non-lethal obstacles. Add edge types
for Costmap3D, where querying the distance to only non-lethal obstacles
is possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/teb_local_planner/13)
<!-- Reviewable:end -->
