### PR TITLE
Fix control law rotational instability

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -127,12 +127,16 @@ grp_control.add("carrot_dt", double_t, 0,
   0.4, 0.0, 10.0)
 
 grp_control.add("carrot_min_dist", double_t, 0,
-  "(meters) If carrot pose is closer than this minimum distance, teporarily increase carrot_dt until it is is this far away (or we reach end of plan)",
+  "(meters) If carrot pose is closer than this minimum distance and carrot_min_angle, temporarily increase carrot_dt until it is is this far away or we reach min_carrot_angle (or end of plan)",
   0.04, 0.0, 1.0)
 
-grp_control.add("turn_in_place_goal_dist", double_t, 0,
-  "(meters) When robot is within the minimum of this distance and the xy_goal_tolerance, switch to turn-in-place control law to finish the goal. Must be greater than zero, else may never terminate.",
-  10.0, 0.001, 10.0)
+grp_control.add("carrot_min_angle", double_t, 0,
+  "(radians) If carrot pose is closer than this minimum angle and carrot_min_dist, temporarily increase carrot_dt until it is is this far away or we reach min_carrot_dist (or end of plan)",
+  0.2, 0.0, math.pi)
+
+grp_control.add("turn_in_place_carrot_dist", double_t, 0,
+  "(meters) When carrot pose is within the minimum of this distance and the xy_goal_tolerance, switch to turn-in-place control law. Must be greater than zero, else may never terminate.",
+  0.04, 0.001, 10.0)
 
 grp_control.add("turn_in_place_Kp", double_t, 0,
   "Proportional gain when turning in place",

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -107,8 +107,9 @@ public:
   struct ControlLaw
   {
     double carrot_dt; //!< (seconds) Look this many seconds ahead of the robot on the plan to choose a carrot pose for control law
-    double carrot_min_dist; //!< (meters) If carrot pose is closer than this minimum distance, teporarily increase carrot_dt until it is is this far away (or we reach end of plan)
-    double turn_in_place_goal_dist; //!< (meters) When robot is within the minimum of this distance and the xy_goal_tolerance, switch to turn-in-place control law to finish the goal
+    double carrot_min_dist; //!< (meters) If carrot pose is closer than this minimum distance and carrot_min_angle, temporarily increase carrot_dt until it is is this far away or we reach min_carrot_angle (or end of plan)
+    double carrot_min_angle; //!< (radians) If carrot pose is closer than this minimum angle and carrot_min_dist, temporarily increase carrot_dt until it is is this far away or we reach min_carrot_dist (or end of plan)
+    double turn_in_place_carrot_dist; //!< (meters) When carrot pose is within the minimum of this distance and the xy_goal_tolerance, switch to turn-in-place control law
     double turn_in_place_Kp; //!< Proportional gain when turning in place
     double turn_in_place_min_vel_theta; //!< (rad/s) Min rotation speed when turning in place. In case motors have a minimum speed
   } control; //!< Control-related parameters
@@ -301,7 +302,8 @@ public:
     // Control Law
     control.carrot_dt = 0.4;
     control.carrot_min_dist = 0.04;
-    control.turn_in_place_goal_dist = 10.0;  // Default disabled. Uses xy_goal_tolerance since it is smaller.
+    control.carrot_min_angle = 0.2;
+    control.turn_in_place_carrot_dist = 0.04;
     control.turn_in_place_Kp = 1.0;
     control.turn_in_place_min_vel_theta = 0.0;
 

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -84,7 +84,8 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   // Control Law
   nh.param("carrot_dt", control.carrot_dt, control.carrot_dt);
   nh.param("carrot_min_dist", control.carrot_min_dist, control.carrot_min_dist);
-  nh.param("turn_in_place_goal_dist", control.turn_in_place_goal_dist, control.turn_in_place_goal_dist);
+  nh.param("carrot_min_angle", control.carrot_min_angle, control.carrot_min_angle);
+  nh.param("turn_in_place_carrot_dist", control.turn_in_place_carrot_dist, control.turn_in_place_carrot_dist);
   nh.param("turn_in_place_Kp", control.turn_in_place_Kp, control.turn_in_place_Kp);
   nh.param("turn_in_place_min_vel_theta", control.turn_in_place_min_vel_theta, control.turn_in_place_min_vel_theta);
 
@@ -236,7 +237,8 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   // Control Law
   control.carrot_dt = cfg.carrot_dt;
   control.carrot_min_dist = cfg.carrot_min_dist;
-  control.turn_in_place_goal_dist = cfg.turn_in_place_goal_dist;
+  control.carrot_min_angle = cfg.carrot_min_angle;
+  control.turn_in_place_carrot_dist = cfg.turn_in_place_carrot_dist;
   control.turn_in_place_Kp = cfg.turn_in_place_Kp;
   control.turn_in_place_min_vel_theta = cfg.turn_in_place_min_vel_theta;
 

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -469,7 +469,8 @@ static PoseSE2 slerp_arc(const PoseSE2& p1, const PoseSE2& p2, double bearing, d
   rot_affine.rotate(angle);
   Eigen::Matrix2d rot_matrix = rot_affine.matrix().block(0, 0, 2, 2);
   result.position() = rot_matrix * (pos1 - center) + center;
-  result.theta() = g2o::normalize_theta(p1.theta() + angle);
+  double deltaTheta = g2o::normalize_theta(p2.theta() - p1.theta());
+  result.theta() = g2o::normalize_theta(p1.theta() + (deltaTheta * fraction));
   return result;
 }
 

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -449,7 +449,7 @@ static PoseSE2 slerp_line(const PoseSE2& p1, const PoseSE2& p2, double fraction)
   PoseSE2 new_pos;
   Eigen::Vector2d deltaPos = p2.position() - p1.position();
   new_pos.position() = p1.position() + (deltaPos * fraction);
-  double deltaTheta = p2.theta() - p1.theta(); // Doesn't need to be normalized yet
+  double deltaTheta = g2o::normalize_theta(p2.theta() - p1.theta());
   new_pos.theta() = g2o::normalize_theta(p1.theta() + (deltaTheta * fraction));
   return new_pos;
 }


### PR DESCRIPTION
Have the control law turn in place when near the carrot pose, and also fix a couple of bugs.

    The previous implementation of the control law special cased a
    rotation in place when near the goal, and looked ahead on the path
    until the carrot was at least carrot_min_dist away. However, if the
    path contains a spiral such that the pose min_carrot_dist away is
    significantly different in orientation than the current orientation
    the control law poorly follows the plan, sometimes turning the wrong
    way.
    
    Deal with this by generalizing the turn-in-place control to activate
    any time the carrot pose at time delta carrot_dt is within
    carrot_min_dist. When the carrot pose is not at the goal, simply
    issue the direct rotational velocity to follow the rotation in the
    plan. If the carrot pose is at the goal, use the P controller to
    prevent over-shooting the goal.
    
    Since turn in place can now happen anywhere along the path, remove
    the now unneeded turn_in_place_goal_dist configuration parameter.

Also fix an interpolation issue when two poses are mostly strafing, and fix a bug in slerp_line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/teb_local_planner/16)
<!-- Reviewable:end -->
